### PR TITLE
Add minimal form builder blocks

### DIFF
--- a/packages/block-contactfield/package.json
+++ b/packages/block-contactfield/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vastreach/block-contactfield",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "dependencies": {
+    "react": "^18",
+    "zod": "^3",
+    "@form-shared": "*"
+  },
+  "scripts": {
+    "build": "tsup src/index.tsx --format esm,cjs --dts"
+  }
+}

--- a/packages/block-contactfield/src/index.tsx
+++ b/packages/block-contactfield/src/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { z } from 'zod';
+import { FieldMeta } from '@form-shared/schema';
+
+export const ContactFieldPropsSchema = z.object({
+  label: z.string().min(1),
+  description: z.string().optional(),
+  meta: FieldMeta,
+});
+
+export type ContactFieldProps = z.infer<typeof ContactFieldPropsSchema>;
+
+export const ContactFieldDefaults: ContactFieldProps = {
+  label: 'First name',
+  description: '',
+  meta: {
+    field_name: 'first_name',
+    required: true,
+    hidden: false,
+    readonly: false,
+    type: 'text',
+    field_options: [],
+  },
+};
+
+export function ContactField({ label, description }: ContactFieldProps) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <label style={{ display: 'block', fontWeight: 600 }}>{label}</label>
+      {description ? (
+        <small style={{ display: 'block', marginBottom: 4 }}>{description}</small>
+      ) : null}
+      <input style={{ width: '100%', padding: 8, border: '1px solid #ccc' }} />
+    </div>
+  );
+}
+
+export default ContactField;

--- a/packages/block-contactfield/tsconfig.json
+++ b/packages/block-contactfield/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "outDir": "dist"
+  },
+  "exclude": ["dist"]
+}

--- a/packages/editor-sample/src/documents/editor/core.tsx
+++ b/packages/editor-sample/src/documents/editor/core.tsx
@@ -10,6 +10,10 @@ import { Image, ImagePropsSchema } from '@usewaypoint/block-image';
 import { Spacer, SpacerPropsSchema } from '@usewaypoint/block-spacer';
 import { Text, TextPropsSchema } from '@usewaypoint/block-text';
 import {
+  ContactField,
+  ContactFieldPropsSchema,
+} from '@vastreach/block-contactfield';
+import {
   buildBlockComponent,
   buildBlockConfigurationDictionary,
   buildBlockConfigurationSchema,
@@ -37,6 +41,14 @@ const EDITOR_DICTIONARY = buildBlockConfigurationDictionary({
     Component: (props) => (
       <EditorBlockWrapper>
         <Button {...props} />
+      </EditorBlockWrapper>
+    ),
+  },
+  ContactField: {
+    schema: ContactFieldPropsSchema,
+    Component: (props) => (
+      <EditorBlockWrapper>
+        <ContactField {...props} />
       </EditorBlockWrapper>
     ),
   },

--- a/packages/email-builder/src/Reader/core.tsx
+++ b/packages/email-builder/src/Reader/core.tsx
@@ -10,6 +10,10 @@ import { Image, ImagePropsSchema } from '@usewaypoint/block-image';
 import { Spacer, SpacerPropsSchema } from '@usewaypoint/block-spacer';
 import { Text, TextPropsSchema } from '@usewaypoint/block-text';
 import {
+  ContactField,
+  ContactFieldPropsSchema,
+} from '@vastreach/block-contactfield';
+import {
   buildBlockComponent,
   buildBlockConfigurationDictionary,
   buildBlockConfigurationSchema,
@@ -49,6 +53,10 @@ const READER_DICTIONARY = buildBlockConfigurationDictionary({
   Button: {
     schema: ButtonPropsSchema,
     Component: Button,
+  },
+  ContactField: {
+    schema: ContactFieldPropsSchema,
+    Component: ContactField,
   },
   Divider: {
     schema: DividerPropsSchema,

--- a/packages/form-shared/package.json
+++ b/packages/form-shared/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@form-shared",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "dependencies": {
+    "zod": "^3"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts"
+  }
+}

--- a/packages/form-shared/src/adapter.ts
+++ b/packages/form-shared/src/adapter.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { FieldMeta } from './schema';
+
+export const BuilderBlockSchema = z.object({
+  type: z.string(),
+  props: z.any(),
+});
+
+export const BuilderJsonSchema = z.object({
+  blocks: z.array(BuilderBlockSchema),
+});
+
+export type BuilderJson = z.infer<typeof BuilderJsonSchema>;
+
+const ContactFieldSection = z.object({
+  type: z.literal('contactfield'),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  contactfield: FieldMeta,
+});
+
+const SectionSchema = z.union([ContactFieldSection]);
+
+export const CreateCustomFormInput = z.object({
+  form: z.object({ sections: z.array(SectionSchema) }),
+});
+
+export type CreateCustomFormInput = z.infer<typeof CreateCustomFormInput>;
+
+export function builderToVastForm(
+  config: BuilderJson,
+  formMeta: Omit<CreateCustomFormInput, 'form'>
+): CreateCustomFormInput {
+  const sections = config.blocks.map((block) => {
+    switch (block.type) {
+      case 'ContactField':
+        return {
+          type: 'contactfield' as const,
+          label: block.props.label,
+          description: block.props.description,
+          contactfield: block.props.meta,
+        };
+      default:
+        throw new Error(`Unsupported block ${block.type}`);
+    }
+  });
+
+  return {
+    ...formMeta,
+    form: { sections },
+  };
+}

--- a/packages/form-shared/src/index.ts
+++ b/packages/form-shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './schema';

--- a/packages/form-shared/src/schema.ts
+++ b/packages/form-shared/src/schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const Hex = z.string().regex(/^#[0-9A-Fa-f]{6}$/);
+
+export const FieldMeta = z.object({
+  field_name: z.string().regex(/^[^:]*$/),
+  required: z.boolean(),
+  hidden: z.boolean(),
+  readonly: z.boolean(),
+  type: z.enum(['text', 'select', 'multi', 'bool', 'number', 'compound', 'optin']),
+  field_options: z.array(z.string()),
+  placeholder: z.string().optional(),
+  max_characters: z.number().optional(),
+  selected_index: z.number().optional(),
+  options_allow_other: z.boolean().optional(),
+});

--- a/packages/form-shared/tsconfig.json
+++ b/packages/form-shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- create `form-shared` package with field schemas and adapter
- add `block-contactfield` React component
- register ContactField block in editor sample and reader

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_b_687678155fb08327bc0f8b2173328fe8